### PR TITLE
Bump actions in GA workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,9 +24,9 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Check out
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         id: node
         with:
           node-version: ${{ env.NODE_VERSION }}
@@ -66,9 +66,9 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Check out
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         id: node
         with:
           node-version: ${{ env.NODE_VERSION }}
@@ -131,9 +131,9 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Check out
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         id: node
         with:
           node-version: ${{ env.NODE_VERSION }}
@@ -175,7 +175,7 @@ jobs:
           exit "$exit_code"
       - name: Send Codecov report
         if: ${{ !env.ACT && github.event_name != 'pull_request' }}
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: Send Qlty coverage report


### PR DESCRIPTION
- Bump `actions/checkout` from `v4` to `v7`
- Bump `actions/setup-node` from `v4` to `v6`
- Bump `codecov/codecov-action` from `v4` to `v7`

Closes #28.