### PR TITLE
Add format scripts for code formatting

### DIFF
--- a/.github/sort-package-json-output.js
+++ b/.github/sort-package-json-output.js
@@ -1,0 +1,24 @@
+const core = require('@actions/core');
+const { promisify } = require('util');
+const exec = promisify(require('child_process').exec);
+
+const getNrOfIssues = async () => {
+  let result = {};
+
+  try {
+    result = await exec(`sort-package-json --check`);
+  } catch (error) {
+    result.stdout = error.stdout;
+  }
+
+  const lines = (result.stdout || '').trim().split(/\r\n|\r|\n/);
+  return lines.filter((line) => line.includes('was not sorted')).length;
+};
+
+const run = async () => ({
+  total: (await getNrOfIssues()) || 0,
+});
+
+run().then((result) => {
+  core.setOutput('issues', result.total);
+});

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,7 @@ jobs:
             Node.js: ${{ steps.node.outputs.node-version }}
             ESLint issues: Checking...
             Prettier issues: Checking...
+            sort-package-json issues: Checking...
           status: in-progress
       - name: Install pnpm
         run: corepack enable && corepack prepare pnpm@${{ env.PNPM_VERSION }} --activate
@@ -101,16 +102,23 @@ jobs:
       - name: Output Prettier results
         id: prettier-output
         run: pnpm ci:prettier || true
+      - name: Lint using sort-package-json
+        run: pnpm lint:sort-package-json || true
+      - name: Output sort-package-json results
+        id: sort-package-json-output
+        run: pnpm ci:sort-package-json || true
       - name: Check results
         run: |
           eslint_issues="${{ steps.eslint-output.outputs.issues }}"
           prettier_issues="${{ steps.prettier-output.outputs.issues }}"
+          sort_package_json_issues="${{ steps.sort-package-json-output.outputs.issues }}"
 
           echo "Total ESLint issues: $eslint_issues"
           echo "Total Prettier issues: $prettier_issues"
+          echo "Total sort-package-json issues: $sort_package_json_issues"
 
           exit_code=1
-          if [ "$eslint_issues" = '0' ] && [ "$prettier_issues" = '0' ]; then
+          if [ "$eslint_issues" = '0' ] && [ "$prettier_issues" = '0' ] && [ "$sort_package_json_issues" = '0' ]; then
             exit_code=0
           fi
           exit "$exit_code"
@@ -124,6 +132,7 @@ jobs:
             Node.js: ${{ steps.node.outputs.node-version }}
             ESLint issues: ${{ steps.eslint-output.outputs.issues || 'Skipped' }}
             Prettier issues: ${{ steps.prettier-output.outputs.issues || 'Skipped' }}
+            sort-package-json issues: ${{ steps.sort-package-json-output.outputs.issues || 'Skipped' }}
           status: ${{ job.status }}
           timestamp: ${{ steps.slack.outputs.slack-timestamp }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Migrate from `@vercel/ncc` to `esbuild`
+- Improve maintainability
 - Migrate from [Yarn] to [pnpm]
+- Migrate from `@vercel/ncc` to `esbuild`
 
 ## [1.3.0] - 2026-07-08
 

--- a/package.json
+++ b/package.json
@@ -1,10 +1,43 @@
 {
   "name": "slack-action",
-  "description": "GitHub Action to send Slack notifications about your pipelines progress.",
   "version": "1.2.0",
+  "description": "GitHub Action to send Slack notifications about your pipelines progress.",
+  "keywords": [
+    "github-action",
+    "slack",
+    "slack-action"
+  ],
+  "homepage": "https://github.com/codedsolar/slack-action#readme",
+  "repository": {
+    "type": "git",
+    "url": "github:codedsolar/slack-action"
+  },
+  "license": "MIT",
   "author": {
     "name": "Victor Popkov",
     "email": "victor@popkov.me"
+  },
+  "main": "lib/index.js",
+  "types": "src/types/index.d.ts",
+  "scripts": {
+    "audit:fix": "pnpm audit --fix",
+    "build": "tsc --noEmit && esbuild src/index.ts --bundle --platform=node --format=cjs --outfile=dist/index.js --target=node24 --minify",
+    "ci:eslint": "eslint --format='./.github/eslint-output.js' .",
+    "ci:jest": "jest --ci --coverage=false --reporters='./.github/jest-output.js' --silent",
+    "ci:prettier": "node ./.github/prettier-output.js",
+    "ci:sort-package-json": "node ./.github/sort-package-json-output.js",
+    "clean": "rm -rf ./coverage/ ./lib/ && find ./src -name '*.js' -type f -delete",
+    "deduplicate": "pnpm dedupe",
+    "format": "npm-run-all format:*",
+    "format:prettier": "prettier --write .",
+    "format:sort-package-json": "sort-package-json",
+    "lint": "npm-run-all --continue-on-error lint:*",
+    "lint:eslint": "eslint .",
+    "lint:prettier": "prettier --check .",
+    "lint:sort-package-json": "sort-package-json --check",
+    "prepare": "npm run build",
+    "test": "npm-run-all --continue-on-error test:*",
+    "test:jest": "jest --coverage"
   },
   "dependencies": {
     "@actions/core": "^2.0.3",
@@ -30,37 +63,10 @@
     "lodash": "^4.18.1",
     "npm-run-all": "^4.1.5",
     "prettier": "^3.9.4",
+    "sort-package-json": "^4.0.0",
     "ts-jest": "^29.4.11",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.63.0"
   },
-  "packageManager": "pnpm@11.10.0",
-  "homepage": "https://github.com/codedsolar/slack-action#readme",
-  "keywords": [
-    "github-action",
-    "slack",
-    "slack-action"
-  ],
-  "license": "MIT",
-  "main": "lib/index.js",
-  "repository": {
-    "type": "git",
-    "url": "github:codedsolar/slack-action"
-  },
-  "scripts": {
-    "audit:fix": "pnpm audit --fix",
-    "build": "tsc --noEmit && esbuild src/index.ts --bundle --platform=node --format=cjs --outfile=dist/index.js --target=node24 --minify",
-    "ci:eslint": "eslint --format='./.github/eslint-output.js' .",
-    "ci:jest": "jest --ci --coverage=false --reporters='./.github/jest-output.js' --silent",
-    "ci:prettier": "node ./.github/prettier-output.js",
-    "clean": "rm -rf ./coverage/ ./lib/ && find ./src -name '*.js' -type f -delete",
-    "deduplicate": "pnpm dedupe",
-    "lint": "npm-run-all --continue-on-error lint:*",
-    "lint:eslint": "eslint .",
-    "lint:prettier": "prettier --check .",
-    "prepare": "npm run build",
-    "test": "npm-run-all --continue-on-error test:*",
-    "test:jest": "jest --coverage"
-  },
-  "types": "src/types/index.d.ts"
+  "packageManager": "pnpm@11.10.0"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,6 +72,9 @@ importers:
       prettier:
         specifier: ^3.9.4
         version: 3.9.4
+      sort-package-json:
+        specifier: ^4.0.0
+        version: 4.0.0
       ts-jest:
         specifier: ^29.4.11
         version: 29.4.11(@babel/core@7.29.7)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.7))(esbuild@0.28.1)(jest-util@30.4.1)(jest@30.4.2(@types/node@26.1.1))(typescript@6.0.3)
@@ -1282,9 +1285,17 @@ packages:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
 
+  detect-indent@7.0.2:
+    resolution: {integrity: sha512-y+8xyqdGLL+6sh0tVeHcfP/QDd8gUgbasolJJpY7NgeQGSZ739bDtSiaiDgtoicy+mtYB81dKLxO9xRhCyIB3A==}
+    engines: {node: '>=12.20'}
+
   detect-newline@3.1.0:
     resolution: {integrity: sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==}
     engines: {node: '>=8'}
+
+  detect-newline@4.0.1:
+    resolution: {integrity: sha512-qE3Veg1YXzGHQhlA6jzebZN2qVf6NX+A7m7qlhCGG30dJixrAQhYOsJjsnBjJkCSmuOPpCk30145fr8FV0bzog==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -1590,6 +1601,9 @@ packages:
     resolution: {integrity: sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==}
     engines: {node: '>= 0.4'}
 
+  git-hooks-list@4.2.1:
+    resolution: {integrity: sha512-WNvqJjOxxs/8ZP9+DWdwWJ7cDsd60NHf39XnD82pDVrKO5q7xfPqpkK6hwEAmBa/ZSEE4IOoR75EzbbIuwGlMw==}
+
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
@@ -1784,6 +1798,10 @@ packages:
   is-number-object@1.1.1:
     resolution: {integrity: sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==}
     engines: {node: '>= 0.4'}
+
+  is-plain-obj@4.1.0:
+    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
+    engines: {node: '>=12'}
 
   is-promise@4.0.0:
     resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
@@ -2533,6 +2551,14 @@ packages:
   slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
+
+  sort-object-keys@2.1.0:
+    resolution: {integrity: sha512-SOiEnthkJKPv2L6ec6HMwhUcN0/lppkeYuN1x63PbyPRrgSPIuBJCiYxYyvWRTtjMlOi14vQUCGUJqS6PLVm8g==}
+
+  sort-package-json@4.0.0:
+    resolution: {integrity: sha512-6aYOlYI9AWioZ+rzu+4zKLmoFqJP0/fHDxrd7X04yqEibikY+5YVF0EYlyGn4v6X2PJY7yAUWV7oeP+i5rOm/g==}
+    engines: {node: '>=22'}
+    hasBin: true
 
   source-map-support@0.5.13:
     resolution: {integrity: sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==}
@@ -4207,7 +4233,11 @@ snapshots:
 
   depd@2.0.0: {}
 
+  detect-indent@7.0.2: {}
+
   detect-newline@3.1.0: {}
+
+  detect-newline@4.0.1: {}
 
   dunder-proto@1.0.1:
     dependencies:
@@ -4631,6 +4661,8 @@ snapshots:
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
 
+  git-hooks-list@4.2.1: {}
+
   glob-parent@6.0.2:
     dependencies:
       is-glob: 4.0.3
@@ -4826,6 +4858,8 @@ snapshots:
     dependencies:
       call-bound: 1.0.4
       has-tostringtag: 1.0.2
+
+  is-plain-obj@4.1.0: {}
 
   is-promise@4.0.0: {}
 
@@ -5764,6 +5798,18 @@ snapshots:
   signal-exit@4.1.0: {}
 
   slash@3.0.0: {}
+
+  sort-object-keys@2.1.0: {}
+
+  sort-package-json@4.0.0:
+    dependencies:
+      detect-indent: 7.0.2
+      detect-newline: 4.0.1
+      git-hooks-list: 4.2.1
+      is-plain-obj: 4.1.0
+      semver: 7.8.5
+      sort-object-keys: 2.1.0
+      tinyglobby: 0.2.17
 
   source-map-support@0.5.13:
     dependencies:


### PR DESCRIPTION
Add `sort-package-json` as a development dependency and incorporate it into `lint`, new `format` scripts and as a part of the CI lint job for consistent `package.json` formatting:

1. Add `sort-package-json` development dependency
2. Add `lint:sort-package-json` script
3. Add `format`, `format:prettier` and `format:sort-package-json` scripts
4. Add `ci:sort-package-json` script
5. Change ci GA workflow lint job to include `sort-package-json` output
6. Fix code formatting issues
7. Update unreleased in `CHANGELOG.md`

Closes #40.