### PR TITLE
Fix issue with ESM-only @actions/core@3 dependency breaking CI scripts

### DIFF
--- a/.github/eslint-output.js
+++ b/.github/eslint-output.js
@@ -1,6 +1,16 @@
-const core = require('@actions/core');
+let core;
+async function getCore() {
+  if (core) return core;
+  try {
+    core = require('@actions/core');
+  } catch {
+    core = await import('@actions/core');
+  }
+  return core;
+}
 
-module.exports = (results) => {
+module.exports = async (results) => {
+  await getCore();
   const summary = results.reduce(
     (result, value) => ({
       ...result,

--- a/.github/jest-output.js
+++ b/.github/jest-output.js
@@ -1,10 +1,18 @@
-const core = require('@actions/core');
+let core;
+async function getCore() {
+  if (core) return core;
+  try {
+    core = require('@actions/core');
+  } catch {
+    core = await import('@actions/core');
+  }
+  return core;
+}
 
-class JestOutput {
-  onRunComplete(testContexts, results) {
+module.exports = class JestOutput {
+  async onRunComplete(testContexts, results) {
+    await getCore();
     core.setOutput('total', results.numTotalTests || 0);
     core.setOutput('passed', results.numPassedTests || 0);
   }
-}
-
-module.exports = JestOutput;
+};

--- a/.github/prettier-output.js
+++ b/.github/prettier-output.js
@@ -1,6 +1,16 @@
-const core = require('@actions/core');
 const { promisify } = require('util');
 const exec = promisify(require('child_process').exec);
+
+let core;
+async function getCore() {
+  if (core) return core;
+  try {
+    core = require('@actions/core');
+  } catch {
+    core = await import('@actions/core');
+  }
+  return core;
+}
 
 const getNrOfIssues = async () => {
   let result = {};
@@ -22,6 +32,9 @@ const run = async () => ({
   total: (await getNrOfIssues()) || 0,
 });
 
-run().then((result) => {
-  core.setOutput('issues', result.total);
-});
+(async () => {
+  await getCore();
+  run().then((result) => {
+    core.setOutput('issues', result.total);
+  });
+})();

--- a/.github/sort-package-json-output.js
+++ b/.github/sort-package-json-output.js
@@ -1,6 +1,16 @@
-const core = require('@actions/core');
 const { promisify } = require('util');
 const exec = promisify(require('child_process').exec);
+
+let core;
+async function getCore() {
+  if (core) return core;
+  try {
+    core = require('@actions/core');
+  } catch {
+    core = await import('@actions/core');
+  }
+  return core;
+}
 
 const getNrOfIssues = async () => {
   let result = {};
@@ -19,6 +29,9 @@ const run = async () => ({
   total: (await getNrOfIssues()) || 0,
 });
 
-run().then((result) => {
-  core.setOutput('issues', result.total);
-});
+(async () => {
+  await getCore();
+  run().then((result) => {
+    core.setOutput('issues', result.total);
+  });
+})();


### PR DESCRIPTION
Use lazy `import()` fallback for `@actions/core` so the CI scripts work with both `v2` (CJS) and `v3` (ESM-only).

Closes #53.