### PR TITLE
Bump dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `@slack/types` and `@slack/web-api` as direct dependencies
+
 ### Changed
 
+- Bump dependencies
 - Improve maintainability
+- Migrate `@actions/core` from `2.0.3` to `3.0.1`
+- Migrate `@actions/github` from `8.0.1` to `9.1.1`
+- Migrate `@slack/bolt` from `4.7.3` to `5.0.0`
 - Migrate from [Yarn] to [pnpm]
 - Migrate from `@vercel/ncc` to `esbuild`
 - Remove obsolete and redundant dependencies

--- a/package.json
+++ b/package.json
@@ -72,5 +72,5 @@
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.64.0"
   },
-  "packageManager": "pnpm@11.10.0"
+  "packageManager": "pnpm@11.15.1"
 }


### PR DESCRIPTION
- Bump `packageManager` from `pnpm@11.10.0` to `pnpm@11.15.1`
- Update unreleased in `CHANGELOG.md`

Closes #41 to finalize changes accumulated during prior related work.